### PR TITLE
Fix 500 error in calculation view

### DIFF
--- a/resources/views/calculations/show.blade.php
+++ b/resources/views/calculations/show.blade.php
@@ -9,7 +9,7 @@
                     <div>
                         <h4>{{ $calculation->name }}</h4>
                         <small class="text-muted">
-                            Creado el {{ $calculation->created_at->format('d/m/Y H:i') }} por {{ $calculation->user->name }}
+                            Creado el {{ $calculation->created_at->format('d/m/Y H:i') }} por {{ optional($calculation->user)->name ?? 'Usuario no encontrado' }}
                         </small>
                     </div>
                     <div class="btn-group">


### PR DESCRIPTION
When viewing a calculation, if the associated user has been deleted, the application would throw a "Trying to get property 'name' of non-object" error, resulting in a 500 Internal Server Error.

This change uses the `optional()` helper in the Blade view to safely access the user's name, preventing the error and displaying a fallback message instead.