### PR TITLE
Fix: Set cif_value during CSV import

### DIFF
--- a/app/Services/CsvImportService.php
+++ b/app/Services/CsvImportService.php
@@ -168,6 +168,8 @@ class CsvImportService
             throw new \Exception("Precio unitario FOB debe ser mayor a 0.");
         }
 
+        $totalFobValue = $quantity * $unitPriceFob;
+
         $itemData = [
             'part_number' => $data['part_number'],
             'description_en' => $data['description_en'],
@@ -178,7 +180,8 @@ class CsvImportService
             'unit_weight' => !empty($data['unit_weight']) ? (float) $data['unit_weight'] : null,
             'quantity' => $quantity,
             'unit_price_fob' => $unitPriceFob,
-            'total_fob_value' => $quantity * $unitPriceFob,
+            'total_fob_value' => $totalFobValue,
+            'cif_value' => $totalFobValue,
         ];
 
         if ($itemData['ice_exempt'] && empty($itemData['ice_exempt_reason'])) {


### PR DESCRIPTION
When importing products from a CSV file, the process was failing with a `SQLSTATE[23502]: Not null violation` error because the `cif_value` column in the `calculation_items` table was not being set.

This change modifies the `CsvImportService` to calculate the `total_fob_value` and assign it to both the `total_fob_value` and `cif_value` fields. This provides a valid default for `cif_value`, resolving the database constraint error and allowing the CSV import to complete successfully.