### PR TITLE
Fix: Prevent not-null violation during CSV import

### DIFF
--- a/app/Services/CsvImportService.php
+++ b/app/Services/CsvImportService.php
@@ -178,6 +178,10 @@ class CsvImportService
             'unit_price_fob' => $unitPriceFob,
             'total_fob_value' => $totalFobValue,
             'cif_value' => $totalFobValue,
+            'total_cost' => $totalFobValue,
+            'unit_cost' => $unitPriceFob,
+            'sale_price' => $totalFobValue,
+            'unit_sale_price' => $unitPriceFob,
         ];
 
         if ($itemData['ice_exempt'] && empty($itemData['ice_exempt_reason'])) {


### PR DESCRIPTION
During the import of products via CSV, a `SQLSTATE[23502]: Not null violation` error occurred because several non-nullable columns in the `calculation_items` table were not being set.

The error message specifically mentioned `cif_value`, but investigation revealed that `total_cost`, `unit_cost`, `sale_price`, and `unit_sale_price` were also missing.

This change modifies the `CsvImportService` to provide initial default values for these fields, derived from the FOB price. These values are consistent with the behavior of the manual creation form and are intended as placeholders until the `TaxCalculationService` runs to calculate the final correct values.