### PR TITLE
fix: Refresh calculation model after updating local expenses

### DIFF
--- a/app/Http/Controllers/CalculationController.php
+++ b/app/Http/Controllers/CalculationController.php
@@ -385,6 +385,8 @@ class CalculationController extends Controller
             'additional_costs_post_tax' => $postTaxCosts,
         ]);
 
+        $calculation->refresh();
+
         $this->taxCalculationService->calculateTaxes($calculation);
 
         return redirect()->route('calculations.show', $calculation)


### PR DESCRIPTION
- Add calculation->refresh() after updating additional costs
- Ensures calculateTaxes() uses fresh data from database
- Fixes issue where deleted/edited expenses still appeared in display tables