### PR TITLE
fix: Specify array type when saving local expenses config to SystemSe…

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -255,8 +255,8 @@ class AdminController extends Controller
             'post_tax_costs' => 'required|array',
         ]);
 
-        SystemSetting::set('default_additional_costs_pre_tax', $request->pre_tax_costs);
-        SystemSetting::set('default_additional_costs_post_tax', $request->post_tax_costs);
+        SystemSetting::set('default_additional_costs_pre_tax', $request->pre_tax_costs, 'array');
+        SystemSetting::set('default_additional_costs_post_tax', $request->post_tax_costs, 'array');
 
         return redirect()->back()->with('success', 'Configuración de gastos locales actualizada.');
     }


### PR DESCRIPTION
…tting

- Add 'array' type parameter to SystemSetting::set() calls in updateLocalExpensesConfig()
- Fixes 'Array to string conversion' error on /admin/local-expenses-config
- Ensures proper JSON encoding of array data in system settings