### PR TITLE
feat: Add user management for administrators

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+
+class UserController extends Controller
+{
+    /**
+     * Middleware to ensure only admins can access user management.
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware(function ($request, $next) {
+            if (!auth()->user()->isAdmin()) {
+                abort(403, 'Acceso denegado. Se requieren permisos de administrador.');
+            }
+            return $next($request);
+        });
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request): View
+    {
+        $query = User::query();
+
+        if ($request->filled('search')) {
+            $search = $request->get('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                  ->orWhere('email', 'like', "%{$search}%");
+            });
+        }
+
+        if ($request->filled('role')) {
+            $query->where('role', $request->get('role'));
+        }
+
+        if ($request->filled('status')) {
+            $query->where('is_active', $request->get('status') === 'active');
+        }
+
+        $users = $query->orderBy('name')->paginate(20);
+
+        return view('admin.users.index', compact('users'));
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(User $user): View
+    {
+        $user->load(['calculations' => function ($query) {
+            $query->orderBy('created_at', 'desc')->take(10);
+        }]);
+
+        return view('admin.users.show', compact('user'));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(User $user): RedirectResponse
+    {
+        // Prevent admin from deleting themselves
+        if ($user->id === auth()->id()) {
+            return redirect()->route('admin.users.index')
+                ->with('error', 'No puedes eliminar tu propia cuenta de administrador.');
+        }
+
+        try {
+            $user->delete();
+            return redirect()->route('admin.users.index')
+                ->with('success', 'Usuario eliminado exitosamente.');
+        } catch (\Exception $e) {
+            return redirect()->route('admin.users.index')
+                ->with('error', 'No se pudo eliminar el usuario. Es posible que tenga datos asociados.');
+        }
+    }
+}

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,0 +1,109 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1><i class="fas fa-users-cog"></i> Gestión de Usuarios</h1>
+    <p class="text-muted">Administrar los usuarios del sistema</p>
+
+    {{-- Search and Filter Form --}}
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0"><i class="fas fa-search"></i> Filtrar y Buscar</h5>
+        </div>
+        <div class="card-body">
+            <form method="GET" action="{{ route('admin.users.index') }}" class="form-inline">
+                <div class="form-group mr-2 mb-2">
+                    <label for="search" class="sr-only">Buscar</label>
+                    <input type="text" class="form-control" id="search" name="search" placeholder="Nombre o email" value="{{ request('search') }}">
+                </div>
+                <div class="form-group mr-2 mb-2">
+                    <label for="role" class="sr-only">Rol</label>
+                    <select class="form-control" id="role" name="role">
+                        <option value="">Todos los roles</option>
+                        <option value="admin" {{ request('role') == 'admin' ? 'selected' : '' }}>Administrador</option>
+                        <option value="user" {{ request('role') == 'user' ? 'selected' : '' }}>Usuario</option>
+                    </select>
+                </div>
+                <div class="form-group mr-2 mb-2">
+                    <label for="status" class="sr-only">Estado</label>
+                    <select class="form-control" id="status" name="status">
+                        <option value="">Todos los estados</option>
+                        <option value="active" {{ request('status') == 'active' ? 'selected' : '' }}>Activo</option>
+                        <option value="inactive" {{ request('status') == 'inactive' ? 'selected' : '' }}>Inactivo</option>
+                    </select>
+                </div>
+                <button type="submit" class="btn btn-primary mb-2"><i class="fas fa-filter"></i> Filtrar</button>
+                <a href="{{ route('admin.users.index') }}" class="btn btn-secondary mb-2 ml-2"><i class="fas fa-sync-alt"></i> Limpiar</a>
+            </form>
+        </div>
+    </div>
+
+    {{-- Users Table --}}
+    <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0"><i class="fas fa-user-friends"></i> Lista de Usuarios</h5>
+            <span class="badge badge-pill badge-primary">{{ $users->total() }} usuarios</span>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>Nombre</th>
+                        <th>Email</th>
+                        <th>Rol</th>
+                        <th>Estado</th>
+                        <th>Registrado el</th>
+                        <th class="text-right">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse ($users as $user)
+                        <tr>
+                            <td>{{ $user->name }}</td>
+                            <td>{{ $user->email }}</td>
+                            <td>
+                                @if ($user->isAdmin())
+                                    <span class="badge badge-success">Admin</span>
+                                @else
+                                    <span class="badge badge-secondary">Usuario</span>
+                                @endif
+                            </td>
+                            <td>
+                                @if ($user->is_active)
+                                    <span class="badge badge-success">Activo</span>
+                                @else
+                                    <span class="badge badge-danger">Inactivo</span>
+                                @endif
+                            </td>
+                            <td>{{ $user->created_at->format('d/m/Y H:i') }}</td>
+                            <td class="text-right">
+                                <a href="{{ route('admin.users.show', $user) }}" class="btn btn-sm btn-info" title="Ver detalles">
+                                    <i class="fas fa-eye"></i>
+                                </a>
+                                @if (auth()->id() !== $user->id)
+                                    <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Estás seguro de que quieres eliminar a este usuario? Esta acción no se puede deshacer.');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-danger" title="Eliminar usuario">
+                                            <i class="fas fa-trash-alt"></i>
+                                        </button>
+                                    </form>
+                                @endif
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">No se encontraron usuarios.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        @if ($users->hasPages())
+            <div class="card-footer">
+                {{ $users->withQueryString()->links() }}
+            </div>
+        @endif
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -1,0 +1,106 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1><i class="fas fa-user-tag"></i> Detalles del Usuario</h1>
+        <a href="{{ route('admin.users.index') }}" class="btn btn-primary">
+            <i class="fas fa-arrow-left"></i> Volver a la lista
+        </a>
+    </div>
+
+    <div class="row">
+        {{-- User Details Card --}}
+        <div class="col-md-6">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fas fa-info-circle"></i> Información Principal</h5>
+                </div>
+                <div class="card-body">
+                    <table class="table table-borderless">
+                        <tbody>
+                            <tr>
+                                <th style="width: 30%;">Nombre:</th>
+                                <td>{{ $user->name }}</td>
+                            </tr>
+                            <tr>
+                                <th>Email:</th>
+                                <td>{{ $user->email }}</td>
+                            </tr>
+                            <tr>
+                                <th>Rol:</th>
+                                <td>
+                                    @if ($user->isAdmin())
+                                        <span class="badge badge-success">Administrador</span>
+                                    @else
+                                        <span class="badge badge-secondary">Usuario</span>
+                                    @endif
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Estado:</th>
+                                <td>
+                                    @if ($user->is_active)
+                                        <span class="badge badge-success">Activo</span>
+                                    @else
+                                        <span class="badge badge-danger">Inactivo</span>
+                                    @endif
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Registrado el:</th>
+                                <td>{{ $user->created_at->format('d/m/Y H:i:s') }}</td>
+                            </tr>
+                            <tr>
+                                <th>Última actualización:</th>
+                                <td>{{ $user->updated_at->diffForHumans() }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="card-footer text-right">
+                    @if (auth()->id() !== $user->id)
+                        <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="d-inline" onsubmit="return confirm('¿Estás seguro de que quieres eliminar a este usuario? Esta acción no se puede deshacer.');">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger">
+                                <i class="fas fa-trash-alt"></i> Eliminar Usuario
+                            </button>
+                        </form>
+                    @else
+                        <button class="btn btn-danger" disabled>
+                            <i class="fas fa-trash-alt"></i> No puedes eliminarte a ti mismo
+                        </button>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        {{-- Recent Activity Card --}}
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fas fa-history"></i> Actividad Reciente</h5>
+                </div>
+                <div class="card-body">
+                    <h6><i class="fas fa-calculator"></i> Últimos 10 Cálculos</h6>
+                    @if ($user->calculations->isEmpty())
+                        <p class="text-muted">Este usuario aún no ha realizado ningún cálculo.</p>
+                    @else
+                        <ul class="list-group list-group-flush">
+                            @foreach ($user->calculations as $calculation)
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    <a href="{{ route('calculations.show', $calculation) }}">
+                                        {{ $calculation->name ?: 'Cálculo sin nombre' }}
+                                    </a>
+                                    <small class="text-muted">{{ $calculation->created_at->diffForHumans() }}</small>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -53,9 +53,18 @@
                                 </a>
 
                                 <div class="dropdown-menu dropdown-menu-end">
+                                    @if (Auth::user()->isAdmin())
+                                        <a class="dropdown-item" href="{{ route('admin.index') }}">
+                                            <i class="fas fa-cog"></i> Panel de Administración
+                                        </a>
+                                        <a class="dropdown-item" href="{{ route('admin.users.index') }}">
+                                            <i class="fas fa-users-cog"></i> Gestión de Usuarios
+                                        </a>
+                                        <div class="dropdown-divider"></div>
+                                    @endif
                                     <a class="dropdown-item" href="{{ route('logout') }}"
                                        onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
-                                        Cerrar Sesión
+                                        <i class="fas fa-sign-out-alt"></i> Cerrar Sesión
                                     </a>
 
                                     <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\CalculationController;
 use App\Http\Controllers\CalculationItemController;
+use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -50,6 +51,9 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/local-expenses-config', [AdminController::class, 'localExpensesConfig'])->name('local-expenses-config');
         Route::post('/local-expenses-config', [AdminController::class, 'updateLocalExpensesConfig'])->name('local-expenses-config.update');
         Route::post('/mass-update-iva', [AdminController::class, 'massUpdateIvaRate'])->name('mass-update-iva');
+
+        // User Management
+        Route::resource('users', UserController::class)->only(['index', 'show', 'destroy']);
     });
 });
 


### PR DESCRIPTION
This commit introduces a new user management feature that is accessible only to administrators. It allows admins to view a list of all registered users, see their details, and delete them.

The following changes have been made:
- Created a `UserController` to handle the logic for listing, viewing, and deleting users. Access is restricted to users with the 'admin' role via middleware.
- Added new routes in `routes/web.php` for user management, protected under the existing admin route group.
- Created two new views:
  - `admin/users/index.blade.php`: Displays a paginated and searchable list of all users.
  - `admin/users/show.blade.php`: Shows detailed information for a single user, including their recent calculations.
- Updated the main layout (`layouts/app.blade.php`) to add a 'Gestión de Usuarios' link to the user dropdown menu, which is only visible to administrators.