### PR TITLE
Fix: Add numeric constraint to user resource route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -53,9 +53,9 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/mass-update-iva', [AdminController::class, 'massUpdateIvaRate'])->name('mass-update-iva');
 
         // User Management
-        Route::resource('users', UserController::class)
-            ->only(['index', 'show', 'destroy'])
-            ->where('user', '[0-9]+');
+        Route::group(['where' => ['user' => '[0-9]+']], function () {
+            Route::resource('users', UserController::class)->only(['index', 'show', 'destroy']);
+        });
     });
 });
 


### PR DESCRIPTION
Adds a `where` clause with a regular expression to the `users` resource route in `routes/web.php` by wrapping it in a Route group. This ensures that the `{user}` parameter in the URL must be numeric.

This prevents the route from incorrectly matching non-numeric strings (such as 'index.blade.php'), which was causing a `QueryException` due to invalid input for the user ID.