### PR TITLE
Fix: Correct user management route definition to resolve 404 error

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -53,9 +53,9 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/mass-update-iva', [AdminController::class, 'massUpdateIvaRate'])->name('mass-update-iva');
 
         // User Management
-        Route::group(['where' => ['user' => '[0-9]+']], function () {
-            Route::resource('users', UserController::class)->only(['index', 'show', 'destroy']);
-        });
+        Route::resource('users', UserController::class)
+            ->only(['index', 'show', 'destroy'])
+            ->where(['user' => '[0-9]+']);
     });
 });
 


### PR DESCRIPTION
The previous route definition for the user management resource was wrapped in a `Route::group` with a `where` constraint. This caused a 404 error for the `index` route (`admin/users`) because the constraint was being incorrectly applied.

This commit refactors the route definition by chaining the `where` constraint directly to the `Route::resource`. This ensures the constraint is only applied to routes with a `{user}` parameter, such as `show` and `destroy`, resolving the 404 error.